### PR TITLE
设置css的linguist-language为Text

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,3 +15,6 @@
 *.PDF	 diff=astextplain
 *.rtf	 diff=astextplain
 *.RTF	 diff=astextplain
+
+# Set css file to linguist-language=Text
+*.css linguist-language=Text


### PR DESCRIPTION
设置css的linguist-language为Text,使Github判断xunfeng为Python项目