### PR TITLE
Fix(Dockerfile) 修复容器不支持中文的问题

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM ubuntu:14.04
 MAINTAINER Medici.Yan@Gmail.com
+ENV LC_ALL C.UTF-8
 ENV TZ=Asia/Shanghai
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-# 换源，根据实际情况
+# apt and pip mirrors
+
 # RUN sed -i 's/archive.ubuntu.com/mirrors.aliyun.com/g' /etc/apt/sources.list \
 #     && mkdir -p ~/.pip \
 #     && echo "[global]" > ~/.pip/pip.conf \


### PR DESCRIPTION
容器编码格式默认为`POSIX`，不支持中文，修改为 `C.UTF-8`