### PR TITLE
fix tomcat plugin verify flag not accurate

### DIFF
--- a/vulscan/vuldb/tomcat_crackpass.py
+++ b/vulscan/vuldb/tomcat_crackpass.py
@@ -20,7 +20,7 @@ def get_plugin_info():
 
 def check(ip, port, timeout):
     error_i = 0
-    flag_list = ['Application Manager', 'Welcome']
+    flag_list = ['/manager/html/reload', 'Tomcat Web Application Manager']
     user_list = ['admin', 'manager', 'tomcat', 'apache', 'root']
     for user in user_list:
         for pass_ in PASSWORD_DIC:


### PR DESCRIPTION
This plugin is not accurate,may lead to some false positives ,for example 

220---------- Welcome to Pure-FTPd [privsep] ----------
220-You are user number 3 of 50 allowed.
220-Local time is now 14:01. Server port: 21.
220-This is a private system - No anonymous login
220-IPv6 connections are also welcome on this server.
220 You will be disconnected after 15 minutes of inactivity.

Welcome is not a good keyword