### PR TITLE
处理自动安装脚本兼容问题

### DIFF
--- a/install/files/xunfeng
+++ b/install/files/xunfeng
@@ -53,7 +53,13 @@ do_stop() {
         rm -f $XUNFENG_PID
         rm -f /var/run/supervisor.sock
     }
-    killall supervisord
+
+    killall supervisord 2>/dev/null || {
+        sdpid=$(ps -ef | grep supervisord | grep -v grep | awk '{print $2}')
+        if [ "$sdpid" -gt 0 ] 2>/dev/null; then
+            kill -9 $sdpid
+        fi
+    }
     echo "XunFeng stopped."
     return 0
 }

--- a/install/files/xunfeng
+++ b/install/files/xunfeng
@@ -52,10 +52,10 @@ do_stop() {
         }
         rm -f $XUNFENG_PID
         rm -f /var/run/supervisor.sock
-    }
+    } 2>/dev/null
 
     killall supervisord 2>/dev/null || {
-        sdpid=$(ps -ef | grep supervisord | grep -v grep | awk '{print $2}')
+        sdpid=$(ps -ef | grep supervisord | grep -v grep | awk '{print $2}') 2>/dev/null || ""
         if [ "$sdpid" -gt 0 ] 2>/dev/null; then
             kill -9 $sdpid
         fi

--- a/install/install.sh
+++ b/install/install.sh
@@ -208,7 +208,10 @@ EOF
     $sh_c 'pip install meld3==1.0.0 -i http://pypi.douban.com/simple/ --trusted-host pypi.douban.com'
     # $sh_c 'wget -qO /tmp/meld3-1.0.2.tar.gz https://pypi.python.org/packages/source/m/meld3/meld3-1.0.2.tar.gz && tar -zxf /tmp/meld3-1.0.2.tar.gz -C /tmp/ && cd /tmp/meld3-1.0.2/ && /usr/bin/env python setup.py install && cd - && rm -rf /tmp/meld3*'
     $sh_c 'pip install -r /opt/xunfeng/requirements.txt -i http://pypi.douban.com/simple/ --trusted-host pypi.douban.com'
-    
+    sdpid=$(ps -ef | grep supervisord | grep -v grep | awk '{print $2}')
+    if [ "$sdpid" -gt 0 ] 2>/dev/null; then
+        kill -9 $sdpid
+    fi
     $sh_c 'chmod a+x /opt/xunfeng/masscan/linux_64/masscan'
     $sh_c 'cp /opt/xunfeng/install/files/xunfeng /etc/init.d/xunfeng'
     $sh_c 'chmod +x /etc/init.d/xunfeng'


### PR DESCRIPTION
* 屏蔽 init.d 脚本 pkill、ps 命令不存在时错误输出
* 首次安装 supervisor 后会自动加载默认配置文件启动，安装完后干掉它