### PR TITLE
修正安装脚本Python版本判断

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -138,7 +138,6 @@ EOF
             if [ ! -f /usr/lib/x86_64-linux-gnu/libpcap.so.1 ]; then
                 $sh_c 'ln -s /usr/lib/x86_64-linux-gnu/libpcap.so /usr/lib/x86_64-linux-gnu/libpcap.so.1'
             fi
-            PY_VERSION=$(/usr/bin/env python -V 2>&1 | awk '{print substr($2,0,4)}')
             ;;
 
         fedora|centos|redhat|oraclelinux|photon)
@@ -166,12 +165,13 @@ EOF
             if ! command_exists start-stop-daemon; then
                 install_start_stop_daemon
             fi
-            PY_VERSION=$(/usr/bin/env python -V 2>&1 | awk '{print substr($2,0,3)}')
             ;;
         *   )
             echo "Either your platform is not easily detectable, is not supported by this installer script."
+            exit
         ;;
     esac
+    PY_VERSION=$(expr "$(/usr/bin/env python -V 2>&1)" : '.*\([0-9]\.[0-9]\)\.[0-9]*')
     echo "Checking Python Version..."
     case "$PY_VERSION" in
         2.7 )


### PR DESCRIPTION
替换原有 awk substr 方式，substr 在不同的发行版和小版本里的参数含义不同，导致判断失败。现改用 expr 正则方式来判断版本号
