### PR TITLE
解决 paramiko 最新版本不兼容 py2 的问题

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ six>=1.6.0
 Flask
 pymongo
 xlwt
-paramiko
+paramiko==1.15.3
 packaging
 appdirs
 gunicorn


### PR DESCRIPTION
使用低版本就不会安装出错了。

具体原因如下：
```
Downloading/unpacking cryptography>=1.5 (from paramiko->-r /opt/xunfeng/requirements.txt (line 5))
  Running setup.py (path:/tmp/pip_build_root/cryptography/setup.py) egg_info for package cryptography
    error in cryptography setup command: Invalid environment marker: python_version < '3'
    Complete output from command python setup.py egg_info:
    error in cryptography setup command: Invalid environment marker: python_version < '3'
```