### PR TITLE
修改pip安装方式

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -133,7 +133,7 @@ EOF
                 fi
             }
             apt_get_update
-            $sh_c 'apt-get install -y -q curl wget unzip gcc libssl-dev libffi-dev python-dev libpcap-dev python-pip git whiptail supervisor'
+            $sh_c 'apt-get install -y -q curl wget unzip gcc libssl-dev libffi-dev python-dev libpcap-dev git whiptail supervisor'
             $sh_c 'pip install -U pip'
             if [ ! -f /usr/lib/x86_64-linux-gnu/libpcap.so.1 ]; then
                 $sh_c 'ln -s /usr/lib/x86_64-linux-gnu/libpcap.so /usr/lib/x86_64-linux-gnu/libpcap.so.1'
@@ -159,7 +159,6 @@ EOF
                 (
                     set -x
                     $sh_c 'sleep 3; yum -y -q install epel-release curl wget unzip gcc git libffi-devel python-devel openssl-devel libpcap-devel newt.x86_64 supervisor ncurses-devel ncurses make g++ gcc-c++ automake autoconf libtool'
-                    $sh_c 'yum -y install python-pip'
                 )
             fi
             if ! command_exists start-stop-daemon; then
@@ -187,6 +186,11 @@ EOF
             exit
             ;;
     esac
+
+    # install pip
+    $sh_c 'curl https://bootstrap.pypa.io/get-pip.py|python2.7'
+    $sh_c 'pip install -U pip'
+	    
 
     if [ ! -d /opt/xunfeng ]; then
         # clone repo

--- a/install/install.sh
+++ b/install/install.sh
@@ -190,7 +190,6 @@ EOF
     $sh_c 'curl https://bootstrap.pypa.io/get-pip.py|python2.7'
     $sh_c 'pip install -U pip'
 	    
-
     if [ ! -d /opt/xunfeng ]; then
         # clone repo
         $sh_c 'git clone ${XUNFENG_REPO} /opt/xunfeng'

--- a/install/install.sh
+++ b/install/install.sh
@@ -134,7 +134,6 @@ EOF
             }
             apt_get_update
             $sh_c 'apt-get install -y -q curl wget unzip gcc libssl-dev libffi-dev python-dev libpcap-dev git whiptail supervisor'
-            $sh_c 'pip install -U pip'
             if [ ! -f /usr/lib/x86_64-linux-gnu/libpcap.so.1 ]; then
                 $sh_c 'ln -s /usr/lib/x86_64-linux-gnu/libpcap.so /usr/lib/x86_64-linux-gnu/libpcap.so.1'
             fi


### PR DESCRIPTION
# 问题日志  
有时从源中安装的pip会有问题，更改更稳定的安装方法

Setting up python-pip-whl (8.1.1-2ubuntu0.4) ...
Setting up python-pip (8.1.1-2ubuntu0.4) ...
Setting up python-wheel (0.29.0-1) ...
Setting up libffi-dev:amd64 (3.2.1-4) ...
Setting up python-meld3 (1.0.2-2) ...
Setting up supervisor (3.2.0-2ubuntu0.1) ...
Processing triggers for libc-bin (2.23-0ubuntu9) ...
Processing triggers for systemd (229-4ubuntu10) ...
Processing triggers for ureadahead (0.100.0-19) ...
The directory '/home/ubuntu/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
The directory '/home/ubuntu/.cache/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
Collecting pip
  Downloading https://files.pythonhosted.org/packages/0f/74/ecd13431bcc456ed390b44c8a6e917c1820365cbebcb6a8974d1cd045ab4/pip-10.0.1-py2.py3-none-any.whl (1.3MB)
    100% |████████████████████████████████| 1.3MB 363kB/s 
Installing collected packages: pip
  Found existing installation: pip 8.1.1
    Not uninstalling pip at /usr/lib/python2.7/dist-packages, outside environment /usr
Successfully installed pip-8.1.1
You are using pip version 8.1.1, however version 10.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Checking Python Version...
Python 2.7.12
Python Version: .... pass
Cloning into '/opt/xunfeng'...
remote: Counting objects: 1844, done.
remote: Compressing objects: 100% (8/8), done.
remote: Total 1844 (delta 4), reused 10 (delta 4), pack-reused 1832
Receiving objects: 100% (1844/1844), 3.01 MiB | 24.00 KiB/s, done.
Resolving deltas: 100% (868/868), done.
Checking connectivity... done.
install mongodb
--2018-05-08 15:04:55--  https://sec.ly.com/mirror/mongodb-linux-x86_64-3.4.0.tgz
Resolving sec.ly.com (sec.ly.com)... 211.159.244.184
Connecting to sec.ly.com (sec.ly.com)|211.159.244.184|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 86429824 (82M) [application/x-compressed]
Saving to: ‘/tmp/mongodb.tgz’

/tmp/mongodb.tgz                             100%[=============================================================================================>]  82.43M  47.4MB/s    in 1.7s    

2018-05-08 15:04:56 (47.4 MB/s) - ‘/tmp/mongodb.tgz’ saved [86429824/86429824]

Traceback (most recent call last):
  File "/usr/local/bin/pip", line 7, in <module>
    from pip._internal import main
ImportError: No module named _internal
root@VM-0-134-ubuntu: # pip install _internal
Traceback (most recent call last):
  File "/usr/local/bin/pip", line 7, in <module>
    from pip._internal import main
ImportError: No module named _internal
root@VM-0-134-ubuntu: # 
root@VM-0-134-ubuntu: # 
root@VM-0-134-ubuntu: # pip
Traceback (most recent call last):
  File "/usr/local/bin/pip", line 7, in <module>
    from pip._internal import main
ImportError: No module named _internal
root@VM-0-134-ubuntu: # ^C
root@VM-0-134-ubuntu: # curl https://bootstrap.pypa.io/get-pip.py|py
py3clean             pyclean              pydoc3               pygettext3           python2              python2-jsondiff     python3.5            pyversions
py3compile           pycompile            pydoc3.5             pygettext3.5         python2.7            python2-jsonpatch    python3.5m           
py3versions          pydoc                pygettext            pygmentize           python2.7-config     python2-jsonpointer  python3m             
pybuild              pydoc2.7             pygettext2.7         python               python2-config       python3              python-config        
root@VM-0-134-ubuntu: # curl https://bootstrap.pypa.io/get-pip.py|python
python               python2.7            python2-config       python2-jsonpatch    python3              python3.5m           python-config        
python2              python2.7-config     python2-jsondiff     python2-jsonpointer  python3.5            python3m             
root@VM-0-134-ubuntu: # curl https://bootstrap.pypa.io/get-pip.py|python2.7
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1603k  100 1603k    0     0   575k      0  0:00:02  0:00:02 --:--:--  575k
The directory '/home/ubuntu/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
The directory '/home/ubuntu/.cache/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
Collecting pip
  Downloading https://files.pythonhosted.org/packages/0f/74/ecd13431bcc456ed390b44c8a6e917c1820365cbebcb6a8974d1cd045ab4/pip-10.0.1-py2.py3-none-any.whl (1.3MB)
    100% |████████████████████████████████| 1.3MB 39kB/s 
Installing collected packages: pip
  Found existing installation: pip 8.1.1
    Uninstalling pip-8.1.1:
      Successfully uninstalled pip-8.1.1
Successfully installed pip-10.0.1
root@VM-0-134-ubuntu: # pip

Usage:   
  pip <command> [options]

Commands:
  install                     Install packages.
  download                    Download packages.
  uninstall                   Uninstall packages.
  freeze                      Output installed packages in requirements format.
  list                        List installed packages.
  show                        Show information about installed packages.
  check                       Verify installed packages have compatible dependencies.
  config                      Manage local and global configuration.
  search                      Search PyPI for packages.
  wheel                       Build wheels from your requirements.
  hash                        Compute hashes of package archives.
  completion                  A helper command used for command completion.
  help                        Show help for commands.
